### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["kpberry"]
 edition = "2021"
 description = "Converts images and gifs to ascii art"
 license = "MIT"
-homepage = "https://github.com/kpberry/image-to-ascii"
+repository = "https://github.com/kpberry/image-to-ascii"
 exclude = ["gallery", ".github"]
 
 [[bin]]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.